### PR TITLE
add support so using sysparm_display_value=all doesn't cause parsing exceptions during query

### DIFF
--- a/ServiceNow.Api.Test/QueryTests.cs
+++ b/ServiceNow.Api.Test/QueryTests.cs
@@ -48,6 +48,22 @@ public class QueryTests : ServiceNowTest
 		Assert.Empty(dupes);
 	}
 
+	[Theory]
+	[InlineData(null, "core_company")]
+	[InlineData("sysparm_display_value=all", "core_company")]
+	public async Task DisplayValueAllTestAsync(string? extraQueryString, string tableName)
+	{
+		// This test fails if the sysparm_display_value=all is specified since the
+		// property value is an object and not something that can parse as a DateTimeOffset
+		const string query = "";
+		const string customOrderByField = "sys_created_on";
+		var fieldList = new List<string> { };
+
+		var result = await Client.GetAllByQueryAsync(tableName, query, fieldList, extraQueryString, customOrderByField).ConfigureAwait(false);
+		Assert.NotNull(result);
+		Assert.NotEmpty(result);
+	}
+
 	[Fact]
 	public async Task PagingTestAsync()
 	{


### PR DESCRIPTION
Currently the use of sysparm_display_value=all breaks the paging logic (the logic that happens when there's more than one page in the query result) which assumes that the property value found via the 'orderByField' will be something we can append a "Z" to then DateTimeOffset.Parse.

https://github.com/panoramicdata/ServiceNow.Api/blob/f856c47b46bb06b44b6fe1863922db6a98bee343/ServiceNow.Api/ServiceNowClient.cs#L348-L351

This fails when you're using sysparm_display_value=all since the value of the orderByField will be a JObject with properties of value and display_value so you end up with an exception during the query similar to this:

String '{
  "display_value": "2024-03-04 21:15:20",
  "value": "2024-03-04 21:15:20"
}Z' was not recognized as a valid DateTime.

This changes the parsing to use DateTimeStyles.AssumeUniversal instead of appending a "Z" and to fall back to DateTimeOffset.MinValue for failure cases instead of throwing an exception.  Since the current code throws an exception, it makes it difficult for query callers that require using sysparm_display_value=all